### PR TITLE
Add Automatic Prompt Engineer implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,52 @@
 # CS4246-APE
+
+This repository provides a reference implementation of Automatic Prompt Engineer (APE) inspired by the paper [Automatic Prompt Engineer](https://arxiv.org/abs/2211.01910). The library exposes a modular search pipeline that can be driven by Hugging Face models or any custom language model backend.
+
+## Features
+
+- Meta-prompt based generation of instruction candidates
+- Evaluation of candidates against validation examples using an arbitrary language model
+- Optional self-refinement step powered by a separate critic model
+- Command line interface for running the search over JSONL datasets
+- Lightweight test suite with deterministic dummy models
+
+## Installation
+
+```bash
+pip install -r requirements.txt
+```
+
+or install the minimum dependencies manually:
+
+```bash
+pip install transformers
+```
+
+## Usage
+
+1. Prepare two JSONL files containing training and evaluation examples. Each line should have the keys `input` and `output`:
+
+```json
+{"input": "5 6", "output": "11"}
+```
+
+2. Run the APE search pipeline:
+
+```bash
+python scripts/run_ape.py \
+  --train path/to/train.jsonl \
+  --eval path/to/eval.jsonl \
+  --generator-model google/flan-t5-base \
+  --task-model google/flan-t5-base \
+  --evaluator-model google/flan-t5-base
+```
+
+The script prints the top instructions along with their validation scores.
+
+## Testing
+
+Run the unit tests with:
+
+```bash
+pytest
+```

--- a/ape/__init__.py
+++ b/ape/__init__.py
@@ -1,0 +1,16 @@
+from .engine import AutomaticPromptEngineer, InferenceConfig, MetaPromptConfig, SearchConfig
+from .language_models import DummyLanguageModel, HuggingFaceLanguageModel, LanguageModel
+from .types import EvaluationResult, Example, PromptCandidate
+
+__all__ = [
+    "AutomaticPromptEngineer",
+    "InferenceConfig",
+    "MetaPromptConfig",
+    "SearchConfig",
+    "DummyLanguageModel",
+    "HuggingFaceLanguageModel",
+    "LanguageModel",
+    "EvaluationResult",
+    "Example",
+    "PromptCandidate",
+]

--- a/ape/engine.py
+++ b/ape/engine.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass
+from typing import Callable, List, Optional, Sequence
+
+from .language_models import LanguageModel
+from .scorers import aggregate_scores
+from .types import EvaluationResult, Example, PromptCandidate
+
+DEFAULT_META_PROMPT = """
+You are an expert prompt designer. Create {count} high-quality instructions for a language model so that it can perform the task shown in the examples. Each instruction should be concise and self-contained.
+
+Format the instructions as a numbered list.
+
+Examples:
+{examples}
+""".strip()
+
+DEFAULT_SELF_EVALUATION_PROMPT = """
+You previously wrote the instruction below:
+{instruction}
+
+It produced incorrect outputs on the following examples:
+{failures}
+
+Revise the instruction to fix the mistakes while keeping it as general as possible. Provide exactly one improved instruction.
+""".strip()
+
+DEFAULT_INFERENCE_TEMPLATE = """
+Instruction:
+{instruction}
+
+Input:
+{input}
+
+Output:
+""".strip()
+
+
+@dataclass
+class MetaPromptConfig:
+    template: str = DEFAULT_META_PROMPT
+    example_separator: str = "\n\n"
+    example_template: str = "Input: {input}\nOutput: {output}"
+
+
+@dataclass
+class InferenceConfig:
+    template: str = DEFAULT_INFERENCE_TEMPLATE
+    stop_sequences: Optional[Sequence[str]] = None
+    max_new_tokens: int = 128
+    temperature: float = 0.0
+    num_return_sequences: int = 1
+    postprocess: Callable[[str], str] = lambda text: text.strip()
+
+
+@dataclass
+class SearchConfig:
+    num_candidates: int = 20
+    candidates_per_round: int = 5
+    refinement_rounds: int = 1
+    top_k_refinement: int = 5
+
+
+class AutomaticPromptEngineer:
+    """Implementation of the Automatic Prompt Engineer (APE) algorithm."""
+
+    def __init__(
+        self,
+        generator_model: LanguageModel,
+        task_model: LanguageModel,
+        *,
+        evaluator_model: Optional[LanguageModel] = None,
+        meta_config: Optional[MetaPromptConfig] = None,
+        inference_config: Optional[InferenceConfig] = None,
+        search_config: Optional[SearchConfig] = None,
+        scorer: Callable[[str, Example], float] = lambda pred, ex: float(pred.strip() == ex.target_text.strip()),
+    ) -> None:
+        self.generator_model = generator_model
+        self.task_model = task_model
+        self.evaluator_model = evaluator_model
+        self.meta_config = meta_config or MetaPromptConfig()
+        self.inference_config = inference_config or InferenceConfig()
+        self.search_config = search_config or SearchConfig()
+        self.scorer = scorer
+
+    # ------------------------------------------------------------------
+    # Candidate generation
+    # ------------------------------------------------------------------
+    def build_meta_prompt(self, examples: Sequence[Example], count: int) -> str:
+        formatted_examples = self.meta_config.example_separator.join(
+            self.meta_config.example_template.format(input=ex.input_text, output=ex.target_text)
+            for ex in examples
+        )
+        return self.meta_config.template.format(count=count, examples=formatted_examples)
+
+    def parse_instructions(self, text: str) -> List[str]:
+        candidates: List[str] = []
+        for line in text.splitlines():
+            match = re.match(r"\s*(?:\d+[\).:-]\s*)?(.*)", line)
+            if not match:
+                continue
+            instruction = match.group(1).strip()
+            if not instruction:
+                continue
+            if instruction.lower().startswith("instruction:"):
+                instruction = instruction.split(":", 1)[1].strip()
+            candidates.append(instruction)
+        # If nothing was parsed, fall back to using the raw text.
+        if not candidates and text.strip():
+            candidates = [text.strip()]
+        # Deduplicate while preserving order.
+        seen = set()
+        unique_candidates = []
+        for cand in candidates:
+            if cand not in seen:
+                unique_candidates.append(cand)
+                seen.add(cand)
+        return unique_candidates
+
+    def generate_candidates(
+        self,
+        train_examples: Sequence[Example],
+        *,
+        num_candidates: Optional[int] = None,
+    ) -> List[PromptCandidate]:
+        search_conf = self.search_config
+        target = num_candidates or search_conf.num_candidates
+        per_round = search_conf.candidates_per_round
+        rounds = math.ceil(target / per_round)
+
+        discovered: List[PromptCandidate] = []
+        for _ in range(rounds):
+            prompt_text = self.build_meta_prompt(train_examples, per_round)
+            generation_batches = self.generator_model.generate(
+                [prompt_text],
+                max_new_tokens=256,
+                temperature=0.8,
+                num_return_sequences=1,
+            )
+            instructions: List[str] = []
+            for batch in generation_batches:
+                for completion in batch:
+                    instructions.extend(self.parse_instructions(completion))
+            for inst in instructions[:per_round]:
+                discovered.append(PromptCandidate(text=inst))
+                if len(discovered) >= target:
+                    break
+            if len(discovered) >= target:
+                break
+        return discovered
+
+    # ------------------------------------------------------------------
+    # Candidate evaluation
+    # ------------------------------------------------------------------
+    def build_inference_prompt(self, instruction: str, example: Example) -> str:
+        return self.inference_config.template.format(
+            instruction=instruction.strip(),
+            input=example.input_text,
+        )
+
+    def evaluate_candidate(self, candidate: PromptCandidate, eval_examples: Sequence[Example]) -> EvaluationResult:
+        prompts = [self.build_inference_prompt(candidate.text, ex) for ex in eval_examples]
+        generations = self.task_model.generate(
+            prompts,
+            max_new_tokens=self.inference_config.max_new_tokens,
+            temperature=self.inference_config.temperature,
+            num_return_sequences=self.inference_config.num_return_sequences,
+            stop_sequences=self.inference_config.stop_sequences,
+        )
+
+        predictions: List[str] = []
+        for completions in generations:
+            first_completion = completions[0] if completions else ""
+            predictions.append(self.inference_config.postprocess(first_completion))
+
+        scores = [self.scorer(pred, ex) for pred, ex in zip(predictions, eval_examples)]
+        avg_score = aggregate_scores(scores)
+        candidate.score = avg_score
+        return EvaluationResult(candidate=candidate, predictions=predictions, references=[ex.target_text for ex in eval_examples], scores=scores)
+
+    def evaluate_candidates(self, candidates: Sequence[PromptCandidate], eval_examples: Sequence[Example]) -> List[EvaluationResult]:
+        results = [self.evaluate_candidate(candidate, eval_examples) for candidate in candidates]
+        return sorted(results, key=lambda res: res.candidate.score or 0.0, reverse=True)
+
+    # ------------------------------------------------------------------
+    # Candidate refinement
+    # ------------------------------------------------------------------
+    def refine_candidates(
+        self,
+        evaluation_results: Sequence[EvaluationResult],
+        eval_examples: Sequence[Example],
+        *,
+        num_refinements: int,
+    ) -> List[PromptCandidate]:
+        if self.evaluator_model is None or num_refinements <= 0:
+            return []
+
+        top_results = list(evaluation_results)[: self.search_config.top_k_refinement]
+        refined_candidates: List[PromptCandidate] = []
+        for result in top_results:
+            failure_cases = []
+            for prediction, example, score in zip(result.predictions, eval_examples, result.scores):
+                if score >= 1.0:
+                    continue
+                failure_cases.append(
+                    f"Input: {example.input_text}\nExpected: {example.target_text}\nModel output: {prediction}"
+                )
+            if not failure_cases:
+                continue
+            prompt = DEFAULT_SELF_EVALUATION_PROMPT.format(
+                instruction=result.candidate.text,
+                failures="\n\n".join(failure_cases[:3]),
+            )
+            generated = self.evaluator_model.generate(
+                [prompt],
+                max_new_tokens=128,
+                temperature=0.3,
+                num_return_sequences=1,
+            )[0]
+            improved_instructions = self.parse_instructions(generated)
+            for inst in improved_instructions[:num_refinements]:
+                refined_candidates.append(PromptCandidate(text=inst))
+        return refined_candidates
+
+    # ------------------------------------------------------------------
+    # Public search API
+    # ------------------------------------------------------------------
+    def search(
+        self,
+        train_examples: Sequence[Example],
+        eval_examples: Sequence[Example],
+    ) -> List[EvaluationResult]:
+        candidates = self.generate_candidates(train_examples)
+        evaluated = self.evaluate_candidates(candidates, eval_examples)
+
+        for _ in range(self.search_config.refinement_rounds):
+            refined = self.refine_candidates(evaluated, eval_examples, num_refinements=1)
+            if not refined:
+                break
+            refined_results = self.evaluate_candidates(refined, eval_examples)
+            evaluated = sorted(evaluated + refined_results, key=lambda res: res.candidate.score or 0.0, reverse=True)
+        return evaluated

--- a/ape/language_models.py
+++ b/ape/language_models.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Iterable, List, Optional, Sequence
+
+try:
+    from transformers import AutoModelForCausalLM, AutoModelForSeq2SeqLM, AutoTokenizer, Pipeline, pipeline
+except ImportError:  # pragma: no cover - optional dependency
+    AutoModelForCausalLM = AutoModelForSeq2SeqLM = AutoTokenizer = Pipeline = None
+    pipeline = None
+
+LOGGER = logging.getLogger(__name__)
+
+
+class LanguageModel(ABC):
+    """Abstract interface for text generation models used by APE."""
+
+    @abstractmethod
+    def generate(
+        self,
+        prompts: Sequence[str],
+        *,
+        max_new_tokens: int = 128,
+        temperature: float = 0.7,
+        num_return_sequences: int = 1,
+        stop_sequences: Optional[Sequence[str]] = None,
+    ) -> List[List[str]]:
+        """Generates continuations for a batch of prompts.
+
+        Returns a list with one entry per prompt. Each entry is a list of generated
+        strings corresponding to ``num_return_sequences`` completions.
+        """
+
+
+@dataclass
+class DummyLanguageModel(LanguageModel):
+    """A deterministic language model used primarily for testing."""
+
+    responses: List[str]
+
+    def generate(
+        self,
+        prompts: Sequence[str],
+        *,
+        max_new_tokens: int = 128,
+        temperature: float = 0.7,
+        num_return_sequences: int = 1,
+        stop_sequences: Optional[Sequence[str]] = None,
+    ) -> List[List[str]]:
+        completions: List[List[str]] = []
+        idx = 0
+        for _ in prompts:
+            outputs: List[str] = []
+            for _ in range(num_return_sequences):
+                if idx >= len(self.responses):
+                    outputs.append("")
+                else:
+                    outputs.append(self.responses[idx])
+                idx += 1
+            completions.append(outputs)
+        return completions
+
+
+class HuggingFaceLanguageModel(LanguageModel):
+    """Wraps Hugging Face transformers models for text generation."""
+
+    def __init__(
+        self,
+        model_name: str,
+        *,
+        task: Optional[str] = None,
+        device: Optional[int] = None,
+        tokenizer_kwargs: Optional[dict] = None,
+        model_kwargs: Optional[dict] = None,
+        pipeline_kwargs: Optional[dict] = None,
+    ) -> None:
+        if pipeline is None:
+            raise ImportError(
+                "transformers is required to use HuggingFaceLanguageModel. Install it with `pip install transformers`."
+            )
+
+        tokenizer_kwargs = tokenizer_kwargs or {}
+        model_kwargs = model_kwargs or {}
+        pipeline_kwargs = pipeline_kwargs or {}
+
+        try:
+            self.tokenizer = AutoTokenizer.from_pretrained(model_name, **tokenizer_kwargs)
+        except Exception as exc:  # pragma: no cover - depends on external model availability
+            raise RuntimeError(f"Failed to load tokenizer for {model_name}: {exc}") from exc
+
+        try:
+            if task == "text2text-generation":
+                model = AutoModelForSeq2SeqLM.from_pretrained(model_name, **model_kwargs)
+                pipeline_task = "text2text-generation"
+            else:
+                try:
+                    model = AutoModelForCausalLM.from_pretrained(model_name, **model_kwargs)
+                    pipeline_task = task or "text-generation"
+                except Exception:
+                    model = AutoModelForSeq2SeqLM.from_pretrained(model_name, **model_kwargs)
+                    pipeline_task = "text2text-generation"
+        except Exception as exc:  # pragma: no cover - external dependency
+            raise RuntimeError(f"Failed to load model for {model_name}: {exc}") from exc
+
+        self.generator: Pipeline = pipeline(
+            pipeline_task,
+            model=model,
+            tokenizer=self.tokenizer,
+            device=device,
+            **pipeline_kwargs,
+        )
+
+    def generate(
+        self,
+        prompts: Sequence[str],
+        *,
+        max_new_tokens: int = 128,
+        temperature: float = 0.7,
+        num_return_sequences: int = 1,
+        stop_sequences: Optional[Sequence[str]] = None,
+    ) -> List[List[str]]:
+        if not isinstance(prompts, (list, tuple)):
+            raise TypeError("prompts must be a sequence of strings")
+
+        generation_args = {
+            "max_new_tokens": max_new_tokens,
+            "temperature": temperature,
+            "num_return_sequences": num_return_sequences,
+            "return_full_text": False,
+        }
+        outputs = self.generator(list(prompts), **generation_args)
+
+        # The HF pipeline returns a flat list when num_return_sequences > 1.
+        # We reshape it back to [batch, sequences].
+        batches: List[List[str]] = []
+        iterator: Iterable[dict] = outputs if isinstance(outputs, list) else [outputs]
+        iterator_list = list(iterator)
+        if num_return_sequences == 1:
+            for item in iterator_list:
+                text = item["generated_text"]
+                batches.append([self._apply_stop_sequences(text, stop_sequences)])
+        else:
+            if len(iterator_list) % len(prompts) != 0:
+                LOGGER.warning("Unexpected number of generations returned by HuggingFace pipeline")
+            completions_per_prompt = len(iterator_list) // len(prompts)
+            for idx in range(0, len(iterator_list), completions_per_prompt):
+                chunk = iterator_list[idx : idx + completions_per_prompt]
+                batches.append([
+                    self._apply_stop_sequences(item["generated_text"], stop_sequences)
+                    for item in chunk
+                ])
+        return batches
+
+    @staticmethod
+    def _apply_stop_sequences(text: str, stop_sequences: Optional[Sequence[str]]) -> str:
+        if not stop_sequences:
+            return text
+        end = len(text)
+        for stop in stop_sequences:
+            pos = text.find(stop)
+            if pos != -1:
+                end = min(end, pos)
+        return text[:end]

--- a/ape/scorers.py
+++ b/ape/scorers.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import math
+from typing import Iterable, Sequence
+
+from .types import Example
+
+
+def exact_match(prediction: str, reference: str) -> float:
+    """Returns 1.0 if the prediction matches the reference exactly."""
+
+    return float(prediction.strip() == reference.strip())
+
+
+def rouge_l(prediction: str, reference: str) -> float:
+    """A light-weight ROUGE-L implementation for non-learning environments."""
+
+    pred_tokens = prediction.split()
+    ref_tokens = reference.split()
+    if not pred_tokens or not ref_tokens:
+        return 0.0
+
+    # Longest common subsequence dynamic programming algorithm.
+    dp = [[0] * (len(ref_tokens) + 1) for _ in range(len(pred_tokens) + 1)]
+    for i in range(1, len(pred_tokens) + 1):
+        for j in range(1, len(ref_tokens) + 1):
+            if pred_tokens[i - 1] == ref_tokens[j - 1]:
+                dp[i][j] = dp[i - 1][j - 1] + 1
+            else:
+                dp[i][j] = max(dp[i - 1][j], dp[i][j - 1])
+
+    lcs = dp[-1][-1]
+    prec = lcs / len(pred_tokens)
+    rec = lcs / len(ref_tokens)
+    if prec == 0 or rec == 0:
+        return 0.0
+    beta = prec / (rec + 1e-12)
+    denom = rec + beta * prec
+    if denom == 0:
+        return 0.0
+    return ((1 + beta ** 2) * prec * rec) / denom
+
+
+def accuracy(predictions: Sequence[str], references: Sequence[str]) -> float:
+    if not predictions:
+        return 0.0
+    total = 0.0
+    for pred, ref in zip(predictions, references):
+        total += exact_match(pred, ref)
+    return total / len(predictions)
+
+
+def aggregate_scores(scores: Iterable[float]) -> float:
+    scores = list(scores)
+    if not scores:
+        return 0.0
+    return sum(scores) / len(scores)
+
+
+def evaluate_predictions(
+    predictions: Sequence[str],
+    examples: Sequence[Example],
+    *,
+    scorer=exact_match,
+) -> Sequence[float]:
+    return [scorer(pred, example.target_text) for pred, example in zip(predictions, examples)]

--- a/ape/types.py
+++ b/ape/types.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class Example:
+    """A single instruction tuning example consisting of input and target text."""
+
+    input_text: str
+    target_text: str
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class PromptCandidate:
+    """Represents a prompt candidate discovered during the search process."""
+
+    text: str
+    score: Optional[float] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class EvaluationResult:
+    """Stores detailed evaluation statistics for a single prompt candidate."""
+
+    candidate: PromptCandidate
+    predictions: List[str]
+    references: List[str]
+    scores: List[float]
+
+    @property
+    def average_score(self) -> float:
+        if not self.scores:
+            return 0.0
+        return sum(self.scores) / len(self.scores)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+transformers>=4.36.0

--- a/scripts/run_ape.py
+++ b/scripts/run_ape.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+from ape.engine import AutomaticPromptEngineer, InferenceConfig, MetaPromptConfig, SearchConfig
+from ape.language_models import HuggingFaceLanguageModel
+from ape.types import Example
+
+
+def load_examples(path: Path) -> List[Example]:
+    if not path.exists():
+        raise FileNotFoundError(path)
+    examples: List[Example] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            record = json.loads(line)
+            try:
+                input_text = record["input"]
+                target_text = record["output"]
+            except KeyError as exc:
+                raise KeyError(f"Missing required field {exc.args[0]!r} in {path}") from exc
+            metadata = {k: v for k, v in record.items() if k not in {"input", "output"}}
+            examples.append(Example(input_text=input_text, target_text=target_text, metadata=metadata))
+    if not examples:
+        raise ValueError(f"No examples loaded from {path}")
+    return examples
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the Automatic Prompt Engineer pipeline")
+    parser.add_argument("--train", type=Path, required=True, help="Path to the training examples (JSONL format)")
+    parser.add_argument("--eval", type=Path, required=True, help="Path to the evaluation examples (JSONL format)")
+    parser.add_argument("--generator-model", type=str, required=True, help="Model identifier for the instruction generator")
+    parser.add_argument("--task-model", type=str, required=True, help="Model identifier for executing the instructions")
+    parser.add_argument("--evaluator-model", type=str, default=None, help="Optional model identifier for self-evaluation")
+    parser.add_argument("--num-candidates", type=int, default=20, help="Total number of instruction candidates to explore")
+    parser.add_argument("--candidates-per-round", type=int, default=5, help="Number of prompts generated per meta-prompt call")
+    parser.add_argument("--refinement-rounds", type=int, default=1, help="Number of self-refinement rounds to run")
+    parser.add_argument("--top-k-refinement", type=int, default=5, help="How many prompts are eligible for refinement")
+    parser.add_argument("--max-new-tokens", type=int, default=128, help="Maximum tokens generated for task model responses")
+    parser.add_argument("--temperature", type=float, default=0.0, help="Temperature used for the task model during evaluation")
+    parser.add_argument("--device", type=int, default=None, help="Device id to load the models on (e.g. 0 for GPU)")
+    parser.add_argument("--meta-prompt", type=Path, default=None, help="Optional path to a custom meta prompt template")
+    parser.add_argument("--inference-template", type=Path, default=None, help="Optional path to a custom inference template")
+    parser.add_argument("--stop", nargs="*", default=None, help="Stop sequences for the task model")
+    return parser.parse_args()
+
+
+def load_template(path: Optional[Path]) -> Optional[str]:
+    if path is None:
+        return None
+    return path.read_text(encoding="utf-8")
+
+
+def main() -> None:
+    args = parse_args()
+
+    train_examples = load_examples(args.train)
+    eval_examples = load_examples(args.eval)
+
+    meta_template = load_template(args.meta_prompt)
+    inference_template = load_template(args.inference_template)
+
+    generator_model = HuggingFaceLanguageModel(args.generator_model, device=args.device)
+    task_model = HuggingFaceLanguageModel(args.task_model, device=args.device)
+    evaluator_model = (
+        HuggingFaceLanguageModel(args.evaluator_model, device=args.device)
+        if args.evaluator_model
+        else None
+    )
+
+    meta_config = MetaPromptConfig(template=meta_template or MetaPromptConfig.template)
+    inference_config = InferenceConfig(
+        template=inference_template or InferenceConfig.template,
+        stop_sequences=args.stop,
+        max_new_tokens=args.max_new_tokens,
+        temperature=args.temperature,
+    )
+    search_config = SearchConfig(
+        num_candidates=args.num_candidates,
+        candidates_per_round=args.candidates_per_round,
+        refinement_rounds=args.refinement_rounds,
+        top_k_refinement=args.top_k_refinement,
+    )
+
+    ape = AutomaticPromptEngineer(
+        generator_model,
+        task_model,
+        evaluator_model=evaluator_model,
+        meta_config=meta_config,
+        inference_config=inference_config,
+        search_config=search_config,
+    )
+
+    results = ape.search(train_examples, eval_examples)
+
+    print("=== Top Instructions ===")
+    for idx, result in enumerate(results[:10], start=1):
+        print(f"[{idx}] Score: {result.candidate.score:.3f}")
+        print(result.candidate.text)
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from typing import List, Sequence
+
+from ape.engine import AutomaticPromptEngineer, SearchConfig
+from ape.language_models import DummyLanguageModel, LanguageModel
+from ape.types import Example
+
+
+class AdditionModel(LanguageModel):
+    """A simple deterministic model that sums integers in the input text."""
+
+    def generate(
+        self,
+        prompts: Sequence[str],
+        *,
+        max_new_tokens: int = 128,
+        temperature: float = 0.7,
+        num_return_sequences: int = 1,
+        stop_sequences: Sequence[str] | None = None,
+    ) -> List[List[str]]:
+        outputs: List[List[str]] = []
+        for prompt in prompts:
+            if "Input:" in prompt:
+                input_text = prompt.split("Input:")[-1]
+            else:
+                input_text = prompt
+            if "Output:" in input_text:
+                input_text = input_text.split("Output:")[0]
+            numbers = [int(token) for token in input_text.split() if token.strip().isdigit()]
+            value = str(sum(numbers)) if numbers else "0"
+            outputs.append([value])
+        return outputs
+
+
+def test_search_discovers_high_scoring_instruction():
+    train_examples = [
+        Example(input_text="1 2", target_text="3"),
+        Example(input_text="3 4", target_text="7"),
+    ]
+    eval_examples = [
+        Example(input_text="5 6", target_text="11"),
+        Example(input_text="10 2", target_text="12"),
+    ]
+
+    generator = DummyLanguageModel([
+        "1. Add the two numbers provided in the input.\n2. Multiply the numbers provided in the input.",
+    ])
+
+    ape = AutomaticPromptEngineer(
+        generator_model=generator,
+        task_model=AdditionModel(),
+        search_config=SearchConfig(num_candidates=2, candidates_per_round=2, refinement_rounds=0),
+    )
+
+    results = ape.search(train_examples, eval_examples)
+    best = results[0]
+    assert "add" in best.candidate.text.lower()
+    assert best.candidate.score == 1.0


### PR DESCRIPTION
## Summary
- implement the Automatic Prompt Engineer core pipeline including candidate generation, evaluation, and optional self-refinement
- add language model interfaces, utility dataclasses, metrics helpers, and a CLI entry point for running the search
- document usage requirements and provide unit tests with deterministic dummy models

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd0d10a4b48333be981524ed248746